### PR TITLE
Add Vertex Aggregation Histogram view

### DIFF
--- a/public/html/dashboard.html
+++ b/public/html/dashboard.html
@@ -79,6 +79,9 @@
             <li>
               <a class="dropdown-item" onclick='openWindow("best_vis.html",540,420)' href="#">Best Individuals</a>
             </li>
+            <li>
+              <a class="dropdown-item" onclick='openWindow("histogram_aggregation_vis.html",900,560)' href="#">Vertex Aggregation Histogram</a>
+            </li>
             
           </ul>
         </li>

--- a/public/html/histogram_aggregation_vis.html
+++ b/public/html/histogram_aggregation_vis.html
@@ -143,7 +143,7 @@
       padding: 6px 8px;
       font-size: 12px;
       line-height: 1.35;
-      white-space: nowrap;
+      white-space: pre-line;
       transform: translate(10px, -10px);
       z-index: 2;
       box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
@@ -195,7 +195,6 @@
   <script type="module">
     import * as d3 from "https://cdn.jsdelivr.net/npm/d3@7/+esm";
 
-    const GROUP_KEYS = ["top1", "top2", "top3", "others", "total"];
     const GROUP_LABELS = {
       top1: "Maior clique",
       top2: "Segundo maior clique",
@@ -364,8 +363,6 @@
       if (innerWidth <= 0 || innerHeight <= 0) return;
 
       const maxValue = d3.max(histogram) || 0;
-      const minValue = d3.min(histogram) || 0;
-
       lastDrawState = {
         activeKey,
         histogram,
@@ -376,7 +373,7 @@
         maxValue
       };
 
-      legendMinEl.textContent = String(minValue);
+      legendMinEl.textContent = "0";
       legendMaxEl.textContent = String(maxValue);
 
       colorScale.domain([0, Math.max(1, maxValue)]);
@@ -493,7 +490,7 @@
       const value = histogram[index] || 0;
       hoverTooltipEl.style.left = `${x}px`;
       hoverTooltipEl.style.top = `${y}px`;
-      hoverTooltipEl.innerHTML = `Vertice ${index + 1}<br>Ocorrencias: ${value}<br>Grupo: ${GROUP_LABELS[activeKey]}`;
+      hoverTooltipEl.textContent = `Vertice ${index + 1}\nOcorrencias: ${value}\nGrupo: ${GROUP_LABELS[activeKey]}`;
       hoverTooltipEl.style.display = "block";
 
       if (hoveredIndex !== index) {

--- a/public/html/histogram_aggregation_vis.html
+++ b/public/html/histogram_aggregation_vis.html
@@ -389,6 +389,11 @@
 			const generationMaxFitness = getGenerationMaxFitness(population);
 			if (generationMaxFitness === null) return;
 
+			//Inicializa o raceFitness.
+			raceFitness.top1 = generationMaxFitness;
+			raceFitness.top2 = generationMaxFitness-1;
+			raceFitness.top3 = generationMaxFitness-2;
+
 			if (raceFitness.top1 === null || generationMaxFitness > raceFitness.top1) {
 				shiftRacePodiumForNewLeader(generationMaxFitness);
 			}

--- a/public/html/histogram_aggregation_vis.html
+++ b/public/html/histogram_aggregation_vis.html
@@ -1,0 +1,590 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vertex Aggregation Histogram</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      background: #f6f8fb;
+      font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+      color: #1e2a3a;
+      overflow: hidden;
+    }
+
+    #app {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      padding: 10px;
+      box-sizing: border-box;
+      gap: 8px;
+    }
+
+    #topBar {
+      background: #ffffff;
+      border: 1px solid #d9e1ec;
+      border-radius: 8px;
+      padding: 10px 12px;
+    }
+
+    #title {
+      margin: 0 0 4px 0;
+      font-size: 18px;
+      font-weight: 700;
+    }
+
+    #status {
+      margin: 0;
+      font-size: 13px;
+      color: #4f647a;
+    }
+
+    #controls {
+      background: #ffffff;
+      border: 1px solid #d9e1ec;
+      border-radius: 8px;
+      padding: 8px 12px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    label {
+      font-size: 13px;
+      color: #33485f;
+      font-weight: 600;
+    }
+
+    select {
+      border: 1px solid #c7d3e2;
+      border-radius: 6px;
+      background: #ffffff;
+      color: #1e2a3a;
+      padding: 6px 8px;
+      font-size: 13px;
+    }
+
+    #legendWrap {
+      margin-left: auto;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 230px;
+    }
+
+    #legendBar {
+      height: 12px;
+      flex: 1;
+      border: 1px solid #c6d1e0;
+      border-radius: 10px;
+      background: linear-gradient(90deg, #f7fbff 0%, #6aaed6 40%, #2b8cbe 70%, #084081 100%);
+    }
+
+    #legendLabels {
+      display: flex;
+      justify-content: space-between;
+      width: 86px;
+      font-size: 11px;
+      color: #40556d;
+      font-weight: 600;
+    }
+
+    #summary {
+      background: #ffffff;
+      border: 1px solid #d9e1ec;
+      border-radius: 8px;
+      padding: 8px 12px;
+      display: flex;
+      gap: 14px;
+      flex-wrap: wrap;
+      font-size: 12px;
+      color: #33485f;
+    }
+
+    .tag {
+      background: #eef4fb;
+      border: 1px solid #d4e1f0;
+      border-radius: 999px;
+      padding: 2px 8px;
+      white-space: nowrap;
+    }
+
+    #chartWrap {
+      flex: 1;
+      min-height: 200px;
+      background: #ffffff;
+      border: 1px solid #d9e1ec;
+      border-radius: 8px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    #histCanvas {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+
+    #hoverTooltip {
+      position: absolute;
+      left: 0;
+      top: 0;
+      display: none;
+      pointer-events: none;
+      background: rgba(17, 38, 64, 0.95);
+      color: #ffffff;
+      border-radius: 6px;
+      padding: 6px 8px;
+      font-size: 12px;
+      line-height: 1.35;
+      white-space: nowrap;
+      transform: translate(10px, -10px);
+      z-index: 2;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    }
+  </style>
+</head>
+<body>
+  <div id="app">
+    <div id="topBar">
+      <h3 id="title">Vertex Aggregation Histogram</h3>
+      <p id="status">Aguardando dados...</p>
+    </div>
+
+    <div id="controls">
+      <label for="groupSelect">Grupo:</label>
+      <select id="groupSelect">
+        <option value="top1">Maior clique</option>
+        <option value="top2">Segundo maior clique</option>
+        <option value="top3">Terceiro maior clique</option>
+        <option value="others">Demais tamanhos</option>
+        <option value="total" selected>Total</option>
+      </select>
+
+      <div id="legendWrap">
+        <div id="legendBar"></div>
+        <div id="legendLabels">
+          <span id="legendMin">0</span>
+          <span id="legendMax">0</span>
+        </div>
+      </div>
+    </div>
+
+    <div id="summary">
+      <span class="tag" id="sumGenerations">Geracoes: 0</span>
+      <span class="tag" id="sumVertices">Vertices: 0</span>
+      <span class="tag" id="sumTop1">Top1 solucoes: 0</span>
+      <span class="tag" id="sumTop2">Top2 solucoes: 0</span>
+      <span class="tag" id="sumTop3">Top3 solucoes: 0</span>
+      <span class="tag" id="sumOthers">Outras solucoes: 0</span>
+      <span class="tag" id="sumTotal">Total solucoes: 0</span>
+    </div>
+
+    <div id="chartWrap">
+      <canvas id="histCanvas"></canvas>
+      <div id="hoverTooltip"></div>
+    </div>
+  </div>
+
+  <script type="module">
+    import * as d3 from "https://cdn.jsdelivr.net/npm/d3@7/+esm";
+
+    const GROUP_KEYS = ["top1", "top2", "top3", "others", "total"];
+    const GROUP_LABELS = {
+      top1: "Maior clique",
+      top2: "Segundo maior clique",
+      top3: "Terceiro maior clique",
+      others: "Demais tamanhos",
+      total: "Total"
+    };
+
+    const canvas = document.getElementById("histCanvas");
+    const chartWrap = document.getElementById("chartWrap");
+    const hoverTooltipEl = document.getElementById("hoverTooltip");
+    const ctx = canvas.getContext("2d");
+
+    const statusEl = document.getElementById("status");
+    const groupSelectEl = document.getElementById("groupSelect");
+
+    const sumGenerationsEl = document.getElementById("sumGenerations");
+    const sumVerticesEl = document.getElementById("sumVertices");
+    const sumTop1El = document.getElementById("sumTop1");
+    const sumTop2El = document.getElementById("sumTop2");
+    const sumTop3El = document.getElementById("sumTop3");
+    const sumOthersEl = document.getElementById("sumOthers");
+    const sumTotalEl = document.getElementById("sumTotal");
+    const legendMinEl = document.getElementById("legendMin");
+    const legendMaxEl = document.getElementById("legendMax");
+
+    const colorScale = d3.scaleSequential(d3.interpolateBlues);
+
+    let vertexCount = 0;
+    let processedGenerations = 0;
+    let currentGeneration = 0;
+    let drawScheduled = false;
+    let hoveredIndex = -1;
+    let lastDrawState = null;
+
+    let counters = {
+      top1: 0,
+      top2: 0,
+      top3: 0,
+      others: 0,
+      total: 0
+    };
+
+    let accumulators = {
+      top1: [],
+      top2: [],
+      top3: [],
+      others: [],
+      total: []
+    };
+
+    function createZeroArray(size) {
+      return Array.from({ length: size }, () => 0);
+    }
+
+    function resetAccumulatorState(newVertexCount = vertexCount) {
+      vertexCount = newVertexCount;
+      accumulators = {
+        top1: createZeroArray(vertexCount),
+        top2: createZeroArray(vertexCount),
+        top3: createZeroArray(vertexCount),
+        others: createZeroArray(vertexCount),
+        total: createZeroArray(vertexCount)
+      };
+      counters = {
+        top1: 0,
+        top2: 0,
+        top3: 0,
+        others: 0,
+        total: 0
+      };
+      processedGenerations = 0;
+      currentGeneration = 0;
+    }
+
+    function ensureAccumulatorSize(size) {
+      if (size !== vertexCount) {
+        resetAccumulatorState(size);
+      }
+    }
+
+    function addMaskToAccumulator(target, nodeMask) {
+      for (let i = 0; i < nodeMask.length; i++) {
+        target[i] += nodeMask[i] ? 1 : 0;
+      }
+    }
+
+    function classifyPopulation(population) {
+      const groupedByFitness = new Map();
+
+      for (const individual of population) {
+        if (!individual || !Array.isArray(individual.nodeMask)) continue;
+        const fitness = Number(individual.fitness ?? 0);
+
+        if (!groupedByFitness.has(fitness)) groupedByFitness.set(fitness, []);
+        groupedByFitness.get(fitness).push(individual.nodeMask);
+      }
+
+      const sortedFitnessLevels = Array.from(groupedByFitness.keys()).sort((a, b) => b - a);
+      const top1Fitness = sortedFitnessLevels[0];
+      const top2Fitness = sortedFitnessLevels[1];
+      const top3Fitness = sortedFitnessLevels[2];
+
+      for (const [fitness, masks] of groupedByFitness.entries()) {
+        const isTop1 = fitness === top1Fitness;
+        const isTop2 = fitness === top2Fitness;
+        const isTop3 = fitness === top3Fitness;
+
+        let bucket = "others";
+        if (isTop1) bucket = "top1";
+        else if (isTop2) bucket = "top2";
+        else if (isTop3) bucket = "top3";
+
+        for (const mask of masks) {
+          addMaskToAccumulator(accumulators[bucket], mask);
+          addMaskToAccumulator(accumulators.total, mask);
+        }
+
+        counters[bucket] += masks.length;
+        counters.total += masks.length;
+      }
+    }
+
+    function scheduleDraw() {
+      if (drawScheduled) return;
+      drawScheduled = true;
+      requestAnimationFrame(() => {
+        drawScheduled = false;
+        drawHistogram();
+      });
+    }
+
+    function updateSummary() {
+      sumGenerationsEl.textContent = `Geracoes: ${processedGenerations}`;
+      sumVerticesEl.textContent = `Vertices: ${vertexCount}`;
+      sumTop1El.textContent = `Top1 solucoes: ${counters.top1}`;
+      sumTop2El.textContent = `Top2 solucoes: ${counters.top2}`;
+      sumTop3El.textContent = `Top3 solucoes: ${counters.top3}`;
+      sumOthersEl.textContent = `Outras solucoes: ${counters.others}`;
+      sumTotalEl.textContent = `Total solucoes: ${counters.total}`;
+    }
+
+    function drawTextMessage(message) {
+      lastDrawState = null;
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = "#5b6f85";
+      ctx.font = "14px Segoe UI";
+      ctx.fillText(message, 16, 24);
+    }
+
+    function drawHistogram() {
+      const activeKey = groupSelectEl.value;
+      const histogram = accumulators[activeKey] || [];
+
+      if (!histogram.length) {
+        legendMinEl.textContent = "0";
+        legendMaxEl.textContent = "0";
+        drawTextMessage("Sem dados para desenhar o histograma.");
+        return;
+      }
+
+      const margin = { top: 14, right: 16, bottom: 28, left: 52 };
+      const innerWidth = canvas.width - margin.left - margin.right;
+      const innerHeight = canvas.height - margin.top - margin.bottom;
+
+      if (innerWidth <= 0 || innerHeight <= 0) return;
+
+      const maxValue = d3.max(histogram) || 0;
+      const minValue = d3.min(histogram) || 0;
+
+      lastDrawState = {
+        activeKey,
+        histogram,
+        margin,
+        innerWidth,
+        innerHeight,
+        barWidth: innerWidth / histogram.length,
+        maxValue
+      };
+
+      legendMinEl.textContent = String(minValue);
+      legendMaxEl.textContent = String(maxValue);
+
+      colorScale.domain([0, Math.max(1, maxValue)]);
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      ctx.strokeStyle = "#9fb0c4";
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(margin.left, margin.top);
+      ctx.lineTo(margin.left, margin.top + innerHeight);
+      ctx.lineTo(margin.left + innerWidth, margin.top + innerHeight);
+      ctx.stroke();
+
+      const yScale = d3.scaleLinear()
+        .domain([0, Math.max(1, maxValue)])
+        .range([margin.top + innerHeight, margin.top]);
+
+      const tickValues = d3.ticks(0, Math.max(1, maxValue), 4);
+      ctx.font = "11px Segoe UI";
+      ctx.fillStyle = "#5d7289";
+      ctx.strokeStyle = "#e5ecf4";
+
+      for (const tick of tickValues) {
+        const y = yScale(tick);
+        ctx.beginPath();
+        ctx.moveTo(margin.left, y);
+        ctx.lineTo(margin.left + innerWidth, y);
+        ctx.stroke();
+
+        ctx.fillStyle = "#5d7289";
+        ctx.fillText(String(Math.round(tick)), 8, y + 4);
+      }
+
+      const barWidth = innerWidth / histogram.length;
+      for (let i = 0; i < histogram.length; i++) {
+        const value = histogram[i];
+        if (!value) continue;
+
+        const barHeight = (value / Math.max(1, maxValue)) * innerHeight;
+        const x = margin.left + i * barWidth;
+        const y = margin.top + innerHeight - barHeight;
+
+        ctx.fillStyle = colorScale(value);
+        ctx.fillRect(x, y, Math.max(1, Math.ceil(barWidth)), barHeight);
+      }
+
+      if (hoveredIndex >= 0 && hoveredIndex < histogram.length) {
+        const highlightX = margin.left + hoveredIndex * barWidth + barWidth / 2;
+        ctx.strokeStyle = "#f08c00";
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(highlightX, margin.top);
+        ctx.lineTo(highlightX, margin.top + innerHeight);
+        ctx.stroke();
+      }
+
+      ctx.fillStyle = "#2f445a";
+      ctx.font = "12px Segoe UI";
+      ctx.fillText(`Vertice 1`, margin.left, canvas.height - 8);
+      ctx.fillText(`Vertice ${histogram.length}`, Math.max(margin.left + 4, canvas.width - 110), canvas.height - 8);
+    }
+
+    function hideTooltip() {
+      hoverTooltipEl.style.display = "none";
+    }
+
+    function handleCanvasHover(event) {
+      if (!lastDrawState) {
+        hideTooltip();
+        return;
+      }
+
+      const rect = canvas.getBoundingClientRect();
+      const x = event.clientX - rect.left;
+      const y = event.clientY - rect.top;
+
+      const {
+        activeKey,
+        histogram,
+        margin,
+        innerWidth,
+        innerHeight,
+        barWidth
+      } = lastDrawState;
+
+      const insidePlot =
+        x >= margin.left &&
+        x <= margin.left + innerWidth &&
+        y >= margin.top &&
+        y <= margin.top + innerHeight;
+
+      if (!insidePlot || barWidth <= 0) {
+        if (hoveredIndex !== -1) {
+          hoveredIndex = -1;
+          scheduleDraw();
+        }
+        hideTooltip();
+        return;
+      }
+
+      const index = Math.floor((x - margin.left) / barWidth);
+      if (index < 0 || index >= histogram.length) {
+        if (hoveredIndex !== -1) {
+          hoveredIndex = -1;
+          scheduleDraw();
+        }
+        hideTooltip();
+        return;
+      }
+
+      const value = histogram[index] || 0;
+      hoverTooltipEl.style.left = `${x}px`;
+      hoverTooltipEl.style.top = `${y}px`;
+      hoverTooltipEl.innerHTML = `Vertice ${index + 1}<br>Ocorrencias: ${value}<br>Grupo: ${GROUP_LABELS[activeKey]}`;
+      hoverTooltipEl.style.display = "block";
+
+      if (hoveredIndex !== index) {
+        hoveredIndex = index;
+        scheduleDraw();
+      }
+    }
+
+    function resizeCanvas() {
+      const bounds = chartWrap.getBoundingClientRect();
+      canvas.width = Math.max(320, Math.floor(bounds.width));
+      canvas.height = Math.max(220, Math.floor(bounds.height));
+      scheduleDraw();
+    }
+
+    groupSelectEl.addEventListener("change", () => {
+      hoveredIndex = -1;
+      hideTooltip();
+      scheduleDraw();
+    });
+
+    canvas.addEventListener("mousemove", handleCanvasHover);
+    canvas.addEventListener("mouseleave", () => {
+      if (hoveredIndex !== -1) {
+        hoveredIndex = -1;
+        scheduleDraw();
+      }
+      hideTooltip();
+    });
+
+    window.addEventListener("resize", resizeCanvas);
+
+    const socket = new WebSocket("ws://localhost:3214");
+
+    socket.onopen = function() {
+      statusEl.textContent = "Conectado ao servidor. Aguardando populacao...";
+      socket.send(JSON.stringify({ act: "obs", data: ["individuals", "ui_events"] }));
+    };
+
+    socket.onmessage = function(event) {
+      const message = JSON.parse(event.data);
+
+      if (message.act === "resetCharts") {
+        resetAccumulatorState(vertexCount);
+        hoveredIndex = -1;
+        hideTooltip();
+        statusEl.textContent = "Processo resetado. Acumuladores limpos automaticamente.";
+        updateSummary();
+        scheduleDraw();
+        return;
+      }
+
+      if (message.act !== "data" || message.type !== "individuals") return;
+      if (!message.data || !Array.isArray(message.data.population) || message.data.population.length === 0) return;
+
+      const population = message.data.population;
+      const maskLength = Array.isArray(population[0].nodeMask) ? population[0].nodeMask.length : 0;
+      if (!maskLength) return;
+
+      const incomingGeneration = Number(message.data.generation || (currentGeneration + 1));
+
+      ensureAccumulatorSize(maskLength);
+
+      if (incomingGeneration < currentGeneration) {
+        resetAccumulatorState(maskLength);
+        hoveredIndex = -1;
+        hideTooltip();
+      }
+
+      classifyPopulation(population);
+
+      processedGenerations++;
+      currentGeneration = incomingGeneration;
+      statusEl.textContent = `Geracao ${currentGeneration} | Populacao ${population.length} | Acumulado em ${processedGenerations} geracoes`;
+
+      updateSummary();
+      scheduleDraw();
+    };
+
+    socket.onerror = function(err) {
+      console.error("Erro WebSocket", err);
+      statusEl.textContent = "Erro de conexao com o WebSocket.";
+    };
+
+    socket.onclose = function() {
+      statusEl.textContent = "Conexao WebSocket encerrada.";
+    };
+
+    resetAccumulatorState(0);
+    updateSummary();
+    resizeCanvas();
+  </script>
+</body>
+</html>

--- a/public/html/histogram_aggregation_vis.html
+++ b/public/html/histogram_aggregation_vis.html
@@ -1,587 +1,776 @@
 <!DOCTYPE html>
-<html lang="pt-br">
+<html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Vertex Aggregation Histogram</title>
-  <style>
-    html, body {
-      margin: 0;
-      padding: 0;
-      width: 100%;
-      height: 100%;
-      background: #f6f8fb;
-      font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-      color: #1e2a3a;
-      overflow: hidden;
-    }
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>Vertex Aggregation Histogram</title>
+	<style>
+		html, body {
+			margin: 0;
+			padding: 0;
+			width: 100%;
+			height: 100%;
+			background: #f6f8fb;
+			font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+			color: #1e2a3a;
+			overflow: hidden;
+		}
 
-    #app {
-      display: flex;
-      flex-direction: column;
-      height: 100%;
-      padding: 10px;
-      box-sizing: border-box;
-      gap: 8px;
-    }
+		#app {
+			display: flex;
+			flex-direction: column;
+			height: 100%;
+			padding: 8px;
+			box-sizing: border-box;
+			gap: 6px;
+		}
 
-    #topBar {
-      background: #ffffff;
-      border: 1px solid #d9e1ec;
-      border-radius: 8px;
-      padding: 10px 12px;
-    }
+		#topBar {
+			background: #ffffff;
+			border: 1px solid #d9e1ec;
+			border-radius: 8px;
+			padding: 8px 10px;
+		}
 
-    #title {
-      margin: 0 0 4px 0;
-      font-size: 18px;
-      font-weight: 700;
-    }
+		#title {
+			margin: 0 0 2px 0;
+			font-size: 17px;
+			font-weight: 700;
+		}
 
-    #status {
-      margin: 0;
-      font-size: 13px;
-      color: #4f647a;
-    }
+		#status {
+			margin: 0;
+			font-size: 12px;
+			color: #4f647a;
+		}
 
-    #controls {
-      background: #ffffff;
-      border: 1px solid #d9e1ec;
-      border-radius: 8px;
-      padding: 8px 12px;
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      flex-wrap: wrap;
-    }
+		#selectorBar {
+			background: #ffffff;
+			border: 1px solid #d9e1ec;
+			border-radius: 8px;
+			padding: 6px 8px;
+			display: flex;
+			flex-wrap: wrap;
+			gap: 6px;
+			align-items: center;
+		}
 
-    label {
-      font-size: 13px;
-      color: #33485f;
-      font-weight: 600;
-    }
+		.check-chip {
+			display: inline-flex;
+			align-items: center;
+			gap: 5px;
+			border: 1px solid #d4e1f0;
+			background: #f7faff;
+			border-radius: 999px;
+			padding: 3px 8px;
+			font-size: 12px;
+			color: #2e4660;
+			user-select: none;
+			white-space: nowrap;
+		}
 
-    select {
-      border: 1px solid #c7d3e2;
-      border-radius: 6px;
-      background: #ffffff;
-      color: #1e2a3a;
-      padding: 6px 8px;
-      font-size: 13px;
-    }
+		.check-chip input {
+			width: 12px;
+			height: 12px;
+			margin: 0;
+			cursor: pointer;
+		}
 
-    #legendWrap {
-      margin-left: auto;
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      min-width: 230px;
-    }
+		.check-label {
+			font-weight: 700;
+		}
 
-    #legendBar {
-      height: 12px;
-      flex: 1;
-      border: 1px solid #c6d1e0;
-      border-radius: 10px;
-      background: linear-gradient(90deg, #f7fbff 0%, #6aaed6 40%, #2b8cbe 70%, #084081 100%);
-    }
+		.check-count {
+			color: #5a738d;
+			font-size: 11px;
+		}
 
-    #legendLabels {
-      display: flex;
-      justify-content: space-between;
-      width: 86px;
-      font-size: 11px;
-      color: #40556d;
-      font-weight: 600;
-    }
+		#chartWrap {
+			flex: 1;
+			min-height: 200px;
+			position: relative;
+			overflow: hidden;
+			background: #ffffff;
+			border: 1px solid #d9e1ec;
+			border-radius: 8px;
+			padding: 6px;
+			box-sizing: border-box;
+		}
 
-    #summary {
-      background: #ffffff;
-      border: 1px solid #d9e1ec;
-      border-radius: 8px;
-      padding: 8px 12px;
-      display: flex;
-      gap: 14px;
-      flex-wrap: wrap;
-      font-size: 12px;
-      color: #33485f;
-    }
+		#chartsStack {
+			height: 100%;
+			width: 100%;
+			display: grid;
+			gap: 6px;
+			overflow: auto;
+			align-content: stretch;
+		}
 
-    .tag {
-      background: #eef4fb;
-      border: 1px solid #d4e1f0;
-      border-radius: 999px;
-      padding: 2px 8px;
-      white-space: nowrap;
-    }
+		.chart-panel {
+			position: relative;
+			background: #ffffff;
+			border: 1px solid #d9e1ec;
+			border-radius: 8px;
+			overflow: hidden;
+			min-height: 170px;
+		}
 
-    #chartWrap {
-      flex: 1;
-      min-height: 200px;
-      background: #ffffff;
-      border: 1px solid #d9e1ec;
-      border-radius: 8px;
-      position: relative;
-      overflow: hidden;
-    }
+		.chart-canvas {
+			width: 100%;
+			height: 100%;
+			display: block;
+		}
 
-    #histCanvas {
-      width: 100%;
-      height: 100%;
-      display: block;
-    }
+		.panel-legend {
+			position: absolute;
+			top: 6px;
+			right: 8px;
+			background: rgba(255, 255, 255, 0.93);
+			border: 1px solid #c7d3e2;
+			border-radius: 8px;
+			padding: 4px 6px;
+			min-width: 150px;
+			z-index: 1;
+			box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+		}
 
-    #hoverTooltip {
-      position: absolute;
-      left: 0;
-      top: 0;
-      display: none;
-      pointer-events: none;
-      background: rgba(17, 38, 64, 0.95);
-      color: #ffffff;
-      border-radius: 6px;
-      padding: 6px 8px;
-      font-size: 12px;
-      line-height: 1.35;
-      white-space: pre-line;
-      transform: translate(10px, -10px);
-      z-index: 2;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-    }
-  </style>
+		.panel-legend-bar {
+			height: 9px;
+			width: 100%;
+			border-radius: 8px;
+			border: 1px solid #c6d1e0;
+			background: linear-gradient(90deg, #c7cdd6 0%, #9db2c8 30%, #6d97bd 58%, #2f73ab 80%, #164f88 100%);
+		}
+
+		.panel-legend-labels {
+			margin-top: 2px;
+			display: flex;
+			justify-content: space-between;
+			font-size: 10px;
+			color: #40556d;
+			font-weight: 600;
+		}
+
+		#emptyState {
+			height: 100%;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			color: #607991;
+			font-size: 13px;
+			text-align: center;
+			padding: 8px;
+			border: 1px dashed #d4deea;
+			border-radius: 8px;
+			background: #f9fbfd;
+		}
+
+		#hoverTooltip {
+			position: absolute;
+			left: 0;
+			top: 0;
+			display: none;
+			pointer-events: none;
+			background: rgba(17, 38, 64, 0.95);
+			color: #ffffff;
+			border-radius: 6px;
+			padding: 6px 8px;
+			font-size: 12px;
+			line-height: 1.35;
+			white-space: pre-line;
+			z-index: 4;
+			box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+			max-width: 260px;
+		}
+
+		@media (max-width: 1024px) {
+			#selectorBar {
+				gap: 5px;
+			}
+
+			.check-chip {
+				padding: 3px 7px;
+			}
+		}
+	</style>
 </head>
 <body>
-  <div id="app">
-    <div id="topBar">
-      <h3 id="title">Vertex Aggregation Histogram</h3>
-      <p id="status">Aguardando dados...</p>
-    </div>
-
-    <div id="controls">
-      <label for="groupSelect">Grupo:</label>
-      <select id="groupSelect">
-        <option value="top1">Maior clique</option>
-        <option value="top2">Segundo maior clique</option>
-        <option value="top3">Terceiro maior clique</option>
-        <option value="others">Demais tamanhos</option>
-        <option value="total" selected>Total</option>
-      </select>
-
-      <div id="legendWrap">
-        <div id="legendBar"></div>
-        <div id="legendLabels">
-          <span id="legendMin">0</span>
-          <span id="legendMax">0</span>
-        </div>
-      </div>
-    </div>
-
-    <div id="summary">
-      <span class="tag" id="sumGenerations">Geracoes: 0</span>
-      <span class="tag" id="sumVertices">Vertices: 0</span>
-      <span class="tag" id="sumTop1">Top1 solucoes: 0</span>
-      <span class="tag" id="sumTop2">Top2 solucoes: 0</span>
-      <span class="tag" id="sumTop3">Top3 solucoes: 0</span>
-      <span class="tag" id="sumOthers">Outras solucoes: 0</span>
-      <span class="tag" id="sumTotal">Total solucoes: 0</span>
-    </div>
-
-    <div id="chartWrap">
-      <canvas id="histCanvas"></canvas>
-      <div id="hoverTooltip"></div>
-    </div>
-  </div>
-
-  <script type="module">
-    import * as d3 from "https://cdn.jsdelivr.net/npm/d3@7/+esm";
-
-    const GROUP_LABELS = {
-      top1: "Maior clique",
-      top2: "Segundo maior clique",
-      top3: "Terceiro maior clique",
-      others: "Demais tamanhos",
-      total: "Total"
-    };
-
-    const canvas = document.getElementById("histCanvas");
-    const chartWrap = document.getElementById("chartWrap");
-    const hoverTooltipEl = document.getElementById("hoverTooltip");
-    const ctx = canvas.getContext("2d");
-
-    const statusEl = document.getElementById("status");
-    const groupSelectEl = document.getElementById("groupSelect");
-
-    const sumGenerationsEl = document.getElementById("sumGenerations");
-    const sumVerticesEl = document.getElementById("sumVertices");
-    const sumTop1El = document.getElementById("sumTop1");
-    const sumTop2El = document.getElementById("sumTop2");
-    const sumTop3El = document.getElementById("sumTop3");
-    const sumOthersEl = document.getElementById("sumOthers");
-    const sumTotalEl = document.getElementById("sumTotal");
-    const legendMinEl = document.getElementById("legendMin");
-    const legendMaxEl = document.getElementById("legendMax");
-
-    const colorScale = d3.scaleSequential(d3.interpolateBlues);
-
-    let vertexCount = 0;
-    let processedGenerations = 0;
-    let currentGeneration = 0;
-    let drawScheduled = false;
-    let hoveredIndex = -1;
-    let lastDrawState = null;
-
-    let counters = {
-      top1: 0,
-      top2: 0,
-      top3: 0,
-      others: 0,
-      total: 0
-    };
-
-    let accumulators = {
-      top1: [],
-      top2: [],
-      top3: [],
-      others: [],
-      total: []
-    };
-
-    function createZeroArray(size) {
-      return Array.from({ length: size }, () => 0);
-    }
-
-    function resetAccumulatorState(newVertexCount = vertexCount) {
-      vertexCount = newVertexCount;
-      accumulators = {
-        top1: createZeroArray(vertexCount),
-        top2: createZeroArray(vertexCount),
-        top3: createZeroArray(vertexCount),
-        others: createZeroArray(vertexCount),
-        total: createZeroArray(vertexCount)
-      };
-      counters = {
-        top1: 0,
-        top2: 0,
-        top3: 0,
-        others: 0,
-        total: 0
-      };
-      processedGenerations = 0;
-      currentGeneration = 0;
-    }
-
-    function ensureAccumulatorSize(size) {
-      if (size !== vertexCount) {
-        resetAccumulatorState(size);
-      }
-    }
-
-    function addMaskToAccumulator(target, nodeMask) {
-      for (let i = 0; i < nodeMask.length; i++) {
-        target[i] += nodeMask[i] ? 1 : 0;
-      }
-    }
-
-    function classifyPopulation(population) {
-      const groupedByFitness = new Map();
-
-      for (const individual of population) {
-        if (!individual || !Array.isArray(individual.nodeMask)) continue;
-        const fitness = Number(individual.fitness ?? 0);
-
-        if (!groupedByFitness.has(fitness)) groupedByFitness.set(fitness, []);
-        groupedByFitness.get(fitness).push(individual.nodeMask);
-      }
-
-      const sortedFitnessLevels = Array.from(groupedByFitness.keys()).sort((a, b) => b - a);
-      const top1Fitness = sortedFitnessLevels[0];
-      const top2Fitness = sortedFitnessLevels[1];
-      const top3Fitness = sortedFitnessLevels[2];
-
-      for (const [fitness, masks] of groupedByFitness.entries()) {
-        const isTop1 = fitness === top1Fitness;
-        const isTop2 = fitness === top2Fitness;
-        const isTop3 = fitness === top3Fitness;
-
-        let bucket = "others";
-        if (isTop1) bucket = "top1";
-        else if (isTop2) bucket = "top2";
-        else if (isTop3) bucket = "top3";
-
-        for (const mask of masks) {
-          addMaskToAccumulator(accumulators[bucket], mask);
-          addMaskToAccumulator(accumulators.total, mask);
-        }
-
-        counters[bucket] += masks.length;
-        counters.total += masks.length;
-      }
-    }
-
-    function scheduleDraw() {
-      if (drawScheduled) return;
-      drawScheduled = true;
-      requestAnimationFrame(() => {
-        drawScheduled = false;
-        drawHistogram();
-      });
-    }
-
-    function updateSummary() {
-      sumGenerationsEl.textContent = `Geracoes: ${processedGenerations}`;
-      sumVerticesEl.textContent = `Vertices: ${vertexCount}`;
-      sumTop1El.textContent = `Top1 solucoes: ${counters.top1}`;
-      sumTop2El.textContent = `Top2 solucoes: ${counters.top2}`;
-      sumTop3El.textContent = `Top3 solucoes: ${counters.top3}`;
-      sumOthersEl.textContent = `Outras solucoes: ${counters.others}`;
-      sumTotalEl.textContent = `Total solucoes: ${counters.total}`;
-    }
-
-    function drawTextMessage(message) {
-      lastDrawState = null;
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      ctx.fillStyle = "#5b6f85";
-      ctx.font = "14px Segoe UI";
-      ctx.fillText(message, 16, 24);
-    }
-
-    function drawHistogram() {
-      const activeKey = groupSelectEl.value;
-      const histogram = accumulators[activeKey] || [];
-
-      if (!histogram.length) {
-        legendMinEl.textContent = "0";
-        legendMaxEl.textContent = "0";
-        drawTextMessage("Sem dados para desenhar o histograma.");
-        return;
-      }
-
-      const margin = { top: 14, right: 16, bottom: 28, left: 52 };
-      const innerWidth = canvas.width - margin.left - margin.right;
-      const innerHeight = canvas.height - margin.top - margin.bottom;
-
-      if (innerWidth <= 0 || innerHeight <= 0) return;
-
-      const maxValue = d3.max(histogram) || 0;
-      lastDrawState = {
-        activeKey,
-        histogram,
-        margin,
-        innerWidth,
-        innerHeight,
-        barWidth: innerWidth / histogram.length,
-        maxValue
-      };
-
-      legendMinEl.textContent = "0";
-      legendMaxEl.textContent = String(maxValue);
-
-      colorScale.domain([0, Math.max(1, maxValue)]);
-
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      ctx.fillStyle = "#ffffff";
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-      ctx.strokeStyle = "#9fb0c4";
-      ctx.lineWidth = 1;
-      ctx.beginPath();
-      ctx.moveTo(margin.left, margin.top);
-      ctx.lineTo(margin.left, margin.top + innerHeight);
-      ctx.lineTo(margin.left + innerWidth, margin.top + innerHeight);
-      ctx.stroke();
-
-      const yScale = d3.scaleLinear()
-        .domain([0, Math.max(1, maxValue)])
-        .range([margin.top + innerHeight, margin.top]);
-
-      const tickValues = d3.ticks(0, Math.max(1, maxValue), 4);
-      ctx.font = "11px Segoe UI";
-      ctx.fillStyle = "#5d7289";
-      ctx.strokeStyle = "#e5ecf4";
-
-      for (const tick of tickValues) {
-        const y = yScale(tick);
-        ctx.beginPath();
-        ctx.moveTo(margin.left, y);
-        ctx.lineTo(margin.left + innerWidth, y);
-        ctx.stroke();
-
-        ctx.fillStyle = "#5d7289";
-        ctx.fillText(String(Math.round(tick)), 8, y + 4);
-      }
-
-      const barWidth = innerWidth / histogram.length;
-      for (let i = 0; i < histogram.length; i++) {
-        const value = histogram[i];
-        if (!value) continue;
-
-        const barHeight = (value / Math.max(1, maxValue)) * innerHeight;
-        const x = margin.left + i * barWidth;
-        const y = margin.top + innerHeight - barHeight;
-
-        ctx.fillStyle = colorScale(value);
-        ctx.fillRect(x, y, Math.max(1, Math.ceil(barWidth)), barHeight);
-      }
-
-      if (hoveredIndex >= 0 && hoveredIndex < histogram.length) {
-        const highlightX = margin.left + hoveredIndex * barWidth + barWidth / 2;
-        ctx.strokeStyle = "#f08c00";
-        ctx.lineWidth = 1;
-        ctx.beginPath();
-        ctx.moveTo(highlightX, margin.top);
-        ctx.lineTo(highlightX, margin.top + innerHeight);
-        ctx.stroke();
-      }
-
-      ctx.fillStyle = "#2f445a";
-      ctx.font = "12px Segoe UI";
-      ctx.fillText(`Vertice 1`, margin.left, canvas.height - 8);
-      ctx.fillText(`Vertice ${histogram.length}`, Math.max(margin.left + 4, canvas.width - 110), canvas.height - 8);
-    }
-
-    function hideTooltip() {
-      hoverTooltipEl.style.display = "none";
-    }
-
-    function handleCanvasHover(event) {
-      if (!lastDrawState) {
-        hideTooltip();
-        return;
-      }
-
-      const rect = canvas.getBoundingClientRect();
-      const x = event.clientX - rect.left;
-      const y = event.clientY - rect.top;
-
-      const {
-        activeKey,
-        histogram,
-        margin,
-        innerWidth,
-        innerHeight,
-        barWidth
-      } = lastDrawState;
-
-      const insidePlot =
-        x >= margin.left &&
-        x <= margin.left + innerWidth &&
-        y >= margin.top &&
-        y <= margin.top + innerHeight;
-
-      if (!insidePlot || barWidth <= 0) {
-        if (hoveredIndex !== -1) {
-          hoveredIndex = -1;
-          scheduleDraw();
-        }
-        hideTooltip();
-        return;
-      }
-
-      const index = Math.floor((x - margin.left) / barWidth);
-      if (index < 0 || index >= histogram.length) {
-        if (hoveredIndex !== -1) {
-          hoveredIndex = -1;
-          scheduleDraw();
-        }
-        hideTooltip();
-        return;
-      }
-
-      const value = histogram[index] || 0;
-      hoverTooltipEl.style.left = `${x}px`;
-      hoverTooltipEl.style.top = `${y}px`;
-      hoverTooltipEl.textContent = `Vertice ${index + 1}\nOcorrencias: ${value}\nGrupo: ${GROUP_LABELS[activeKey]}`;
-      hoverTooltipEl.style.display = "block";
-
-      if (hoveredIndex !== index) {
-        hoveredIndex = index;
-        scheduleDraw();
-      }
-    }
-
-    function resizeCanvas() {
-      const bounds = chartWrap.getBoundingClientRect();
-      canvas.width = Math.max(320, Math.floor(bounds.width));
-      canvas.height = Math.max(220, Math.floor(bounds.height));
-      scheduleDraw();
-    }
-
-    groupSelectEl.addEventListener("change", () => {
-      hoveredIndex = -1;
-      hideTooltip();
-      scheduleDraw();
-    });
-
-    canvas.addEventListener("mousemove", handleCanvasHover);
-    canvas.addEventListener("mouseleave", () => {
-      if (hoveredIndex !== -1) {
-        hoveredIndex = -1;
-        scheduleDraw();
-      }
-      hideTooltip();
-    });
-
-    window.addEventListener("resize", resizeCanvas);
-
-    const socket = new WebSocket("ws://localhost:3214");
-
-    socket.onopen = function() {
-      statusEl.textContent = "Conectado ao servidor. Aguardando populacao...";
-      socket.send(JSON.stringify({ act: "obs", data: ["individuals", "ui_events"] }));
-    };
-
-    socket.onmessage = function(event) {
-      const message = JSON.parse(event.data);
-
-      if (message.act === "resetCharts") {
-        resetAccumulatorState(vertexCount);
-        hoveredIndex = -1;
-        hideTooltip();
-        statusEl.textContent = "Processo resetado. Acumuladores limpos automaticamente.";
-        updateSummary();
-        scheduleDraw();
-        return;
-      }
-
-      if (message.act !== "data" || message.type !== "individuals") return;
-      if (!message.data || !Array.isArray(message.data.population) || message.data.population.length === 0) return;
-
-      const population = message.data.population;
-      const maskLength = Array.isArray(population[0].nodeMask) ? population[0].nodeMask.length : 0;
-      if (!maskLength) return;
-
-      const incomingGeneration = Number(message.data.generation || (currentGeneration + 1));
-
-      ensureAccumulatorSize(maskLength);
-
-      if (incomingGeneration < currentGeneration) {
-        resetAccumulatorState(maskLength);
-        hoveredIndex = -1;
-        hideTooltip();
-      }
-
-      classifyPopulation(population);
-
-      processedGenerations++;
-      currentGeneration = incomingGeneration;
-      statusEl.textContent = `Geracao ${currentGeneration} | Populacao ${population.length} | Acumulado em ${processedGenerations} geracoes`;
-
-      updateSummary();
-      scheduleDraw();
-    };
-
-    socket.onerror = function(err) {
-      console.error("Erro WebSocket", err);
-      statusEl.textContent = "Erro de conexao com o WebSocket.";
-    };
-
-    socket.onclose = function() {
-      statusEl.textContent = "Conexao WebSocket encerrada.";
-    };
-
-    resetAccumulatorState(0);
-    updateSummary();
-    resizeCanvas();
-  </script>
+	<div id="app">
+		<div id="topBar">
+			<h3 id="title">Vertex Aggregation Histogram</h3>
+			<p id="status">Waiting for data...</p>
+		</div>
+
+		<div id="selectorBar">
+			<label class="check-chip">
+				<input id="chk-total" type="checkbox" checked />
+				<span class="check-label">Total</span>
+				<span id="count-total" class="check-count">0</span>
+			</label>
+			<label class="check-chip">
+				<input id="chk-top1" type="checkbox" />
+				<span class="check-label">Top 1</span>
+				<span id="count-top1" class="check-count">0</span>
+			</label>
+			<label class="check-chip">
+				<input id="chk-top2" type="checkbox" />
+				<span class="check-label">Top 2</span>
+				<span id="count-top2" class="check-count">0</span>
+			</label>
+			<label class="check-chip">
+				<input id="chk-top3" type="checkbox" />
+				<span class="check-label">Top 3</span>
+				<span id="count-top3" class="check-count">0</span>
+			</label>
+			<label class="check-chip">
+				<input id="chk-others" type="checkbox" />
+				<span class="check-label">Others</span>
+				<span id="count-others" class="check-count">0</span>
+			</label>
+		</div>
+
+		<div id="chartWrap">
+			<div id="chartsStack"></div>
+			<div id="hoverTooltip"></div>
+		</div>
+	</div>
+
+	<script type="module">
+		import * as d3 from "https://cdn.jsdelivr.net/npm/d3@7/+esm";
+
+		const GROUP_CONFIG = [
+			{ key: "total", label: "Total" },
+			{ key: "top1", label: "Top 1" },
+			{ key: "top2", label: "Top 2" },
+			{ key: "top3", label: "Top 3" },
+			{ key: "others", label: "Others" }
+		];
+
+		const GROUP_LABELS = GROUP_CONFIG.reduce((acc, cur) => {
+			acc[cur.key] = cur.label;
+			return acc;
+		}, {});
+
+		const chartWrapEl = document.getElementById("chartWrap");
+		const chartsStackEl = document.getElementById("chartsStack");
+		const hoverTooltipEl = document.getElementById("hoverTooltip");
+		const statusEl = document.getElementById("status");
+
+		const checkboxes = {
+			total: document.getElementById("chk-total"),
+			top1: document.getElementById("chk-top1"),
+			top2: document.getElementById("chk-top2"),
+			top3: document.getElementById("chk-top3"),
+			others: document.getElementById("chk-others")
+		};
+
+		const countEls = {
+			total: document.getElementById("count-total"),
+			top1: document.getElementById("count-top1"),
+			top2: document.getElementById("count-top2"),
+			top3: document.getElementById("count-top3"),
+			others: document.getElementById("count-others")
+		};
+
+		const colorScale = d3.scaleSequential(
+			d3.interpolateRgbBasis(["#c7cdd6", "#9db2c8", "#6d97bd", "#2f73ab", "#164f88"])
+		);
+
+		let vertexCount = 0;
+		let processedGenerations = 0;
+		let currentGeneration = 0;
+		let drawScheduled = false;
+
+		let counters = {
+			total: 0,
+			top1: 0,
+			top2: 0,
+			top3: 0,
+			others: 0
+		};
+
+		let raceFitness = {
+			top1: null,
+			top2: null,
+			top3: null
+		};
+
+		let accumulators = {
+			total: [],
+			top1: [],
+			top2: [],
+			top3: [],
+			others: []
+		};
+
+		const panelStateByKey = new Map();
+
+		function createZeroArray(size) {
+			return Array.from({ length: size }, () => 0);
+		}
+
+		function resetAccumulatorState(newVertexCount = vertexCount) {
+			vertexCount = newVertexCount;
+			accumulators = {
+				total: createZeroArray(vertexCount),
+				top1: createZeroArray(vertexCount),
+				top2: createZeroArray(vertexCount),
+				top3: createZeroArray(vertexCount),
+				others: createZeroArray(vertexCount)
+			};
+			counters = {
+				total: 0,
+				top1: 0,
+				top2: 0,
+				top3: 0,
+				others: 0
+			};
+			raceFitness = {
+				top1: null,
+				top2: null,
+				top3: null
+			};
+			processedGenerations = 0;
+			currentGeneration = 0;
+		}
+
+		function ensureAccumulatorSize(size) {
+			if (size !== vertexCount) {
+				resetAccumulatorState(size);
+			}
+		}
+
+		function addMaskToAccumulator(target, nodeMask) {
+			for (let i = 0; i < nodeMask.length; i++) {
+				target[i] += nodeMask[i] ? 1 : 0;
+			}
+		}
+
+		function addAccumulatorToAccumulator(target, source) {
+			for (let i = 0; i < target.length && i < source.length; i++) {
+				target[i] += source[i];
+			}
+		}
+
+		function shiftRacePodiumForNewLeader(newTopFitness) {
+			if (raceFitness.top3 !== null) {
+				addAccumulatorToAccumulator(accumulators.others, accumulators.top3);
+				counters.others += counters.top3;
+			}
+
+			accumulators.top3 = accumulators.top2.slice();
+			counters.top3 = counters.top2;
+			raceFitness.top3 = raceFitness.top2;
+
+			accumulators.top2 = accumulators.top1.slice();
+			counters.top2 = counters.top1;
+			raceFitness.top2 = raceFitness.top1;
+
+			accumulators.top1 = createZeroArray(vertexCount);
+			counters.top1 = 0;
+			raceFitness.top1 = newTopFitness;
+		}
+
+		function getGenerationMaxFitness(population) {
+			let maxFitness = null;
+
+			for (const individual of population) {
+				if (!individual || !Array.isArray(individual.nodeMask)) continue;
+				const fitness = Number(individual.fitness ?? 0);
+				if (maxFitness === null || fitness > maxFitness) {
+					maxFitness = fitness;
+				}
+			}
+
+			return maxFitness;
+		}
+
+		function classifyPopulation(population) {
+			const generationMaxFitness = getGenerationMaxFitness(population);
+			if (generationMaxFitness === null) return;
+
+			if (raceFitness.top1 === null || generationMaxFitness > raceFitness.top1) {
+				shiftRacePodiumForNewLeader(generationMaxFitness);
+			}
+
+			for (const individual of population) {
+				if (!individual || !Array.isArray(individual.nodeMask)) continue;
+				const fitness = Number(individual.fitness ?? 0);
+
+				let bucket = "others";
+				if (raceFitness.top1 !== null && fitness === raceFitness.top1) bucket = "top1";
+				else if (raceFitness.top2 !== null && fitness === raceFitness.top2) bucket = "top2";
+				else if (raceFitness.top3 !== null && fitness === raceFitness.top3) bucket = "top3";
+
+				addMaskToAccumulator(accumulators[bucket], individual.nodeMask);
+				addMaskToAccumulator(accumulators.total, individual.nodeMask);
+				counters[bucket] += 1;
+				counters.total += 1;
+			}
+		}
+
+		function updateCounts() {
+			countEls.total.textContent = String(counters.total);
+			countEls.top1.textContent = String(counters.top1);
+			countEls.top2.textContent = String(counters.top2);
+			countEls.top3.textContent = String(counters.top3);
+			countEls.others.textContent = String(counters.others);
+		}
+
+		function getSelectedKeys() {
+			return GROUP_CONFIG
+				.map((group) => group.key)
+				.filter((key) => checkboxes[key].checked);
+		}
+
+		function hideTooltip() {
+			hoverTooltipEl.style.display = "none";
+		}
+
+		function positionTooltip(event) {
+			const wrapRect = chartWrapEl.getBoundingClientRect();
+			const pointerX = event.clientX - wrapRect.left;
+			const pointerY = event.clientY - wrapRect.top;
+
+			let left = pointerX + 12;
+			let top = pointerY - hoverTooltipEl.offsetHeight - 8;
+
+			if (left + hoverTooltipEl.offsetWidth > wrapRect.width - 4) {
+				left = pointerX - hoverTooltipEl.offsetWidth - 12;
+			}
+			if (left < 4) left = 4;
+
+			if (top < 4) top = pointerY + 12;
+			if (top + hoverTooltipEl.offsetHeight > wrapRect.height - 4) {
+				top = Math.max(4, wrapRect.height - hoverTooltipEl.offsetHeight - 4);
+			}
+
+			hoverTooltipEl.style.left = `${left}px`;
+			hoverTooltipEl.style.top = `${top}px`;
+		}
+
+		function drawNoDataMessage(ctx, canvas, message) {
+			ctx.clearRect(0, 0, canvas.width, canvas.height);
+			ctx.fillStyle = "#ffffff";
+			ctx.fillRect(0, 0, canvas.width, canvas.height);
+			ctx.fillStyle = "#5b6f85";
+			ctx.font = "13px Segoe UI";
+			ctx.fillText(message, 14, 22);
+		}
+
+		function drawYAxisAndGrid(ctx, margin, innerWidth, innerHeight, maxValue) {
+			ctx.strokeStyle = "#9fb0c4";
+			ctx.lineWidth = 1;
+			ctx.beginPath();
+			ctx.moveTo(margin.left, margin.top);
+			ctx.lineTo(margin.left, margin.top + innerHeight);
+			ctx.lineTo(margin.left + innerWidth, margin.top + innerHeight);
+			ctx.stroke();
+
+			const yScale = d3.scaleLinear()
+				.domain([0, Math.max(1, maxValue)])
+				.range([margin.top + innerHeight, margin.top]);
+
+			const tickValues = d3.ticks(0, Math.max(1, maxValue), 4);
+			ctx.font = "11px Segoe UI";
+			ctx.fillStyle = "#5d7289";
+			ctx.strokeStyle = "#e5ecf4";
+
+			for (const tick of tickValues) {
+				const y = yScale(tick);
+				ctx.beginPath();
+				ctx.moveTo(margin.left, y);
+				ctx.lineTo(margin.left + innerWidth, y);
+				ctx.stroke();
+				ctx.fillText(String(Math.round(tick)), 8, y + 4);
+			}
+		}
+
+		function renderPanel(panelState) {
+			const { key, canvas, ctx, legendMin, legendMax } = panelState;
+			const histogram = accumulators[key] || [];
+
+			const width = Math.max(320, Math.floor(canvas.clientWidth));
+			const height = Math.max(170, Math.floor(canvas.clientHeight));
+			canvas.width = width;
+			canvas.height = height;
+
+			if (!histogram.length) {
+				legendMin.textContent = "0";
+				legendMax.textContent = "0";
+				panelState.drawMeta = null;
+				drawNoDataMessage(ctx, canvas, `No data available for ${GROUP_LABELS[key]}.`);
+				return;
+			}
+
+			const margin = { top: 14, right: 16, bottom: 28, left: 52 };
+			const innerWidth = canvas.width - margin.left - margin.right;
+			const innerHeight = canvas.height - margin.top - margin.bottom;
+
+			if (innerWidth <= 0 || innerHeight <= 0) {
+				panelState.drawMeta = null;
+				return;
+			}
+
+			const maxValue = d3.max(histogram) || 0;
+			const barWidth = innerWidth / histogram.length;
+			colorScale.domain([0, Math.max(1, maxValue)]);
+
+			legendMin.textContent = "0";
+			legendMax.textContent = String(maxValue);
+
+			ctx.clearRect(0, 0, canvas.width, canvas.height);
+			ctx.fillStyle = "#ffffff";
+			ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+			drawYAxisAndGrid(ctx, margin, innerWidth, innerHeight, maxValue);
+
+			for (let i = 0; i < histogram.length; i++) {
+				const value = histogram[i];
+				if (!value) continue;
+
+				const barHeight = (value / Math.max(1, maxValue)) * innerHeight;
+				const x = margin.left + i * barWidth;
+				const y = margin.top + innerHeight - barHeight;
+
+				ctx.fillStyle = colorScale(value);
+				ctx.fillRect(x, y, Math.max(1, Math.ceil(barWidth)), barHeight);
+			}
+
+			if (panelState.hoveredIndex >= 0 && panelState.hoveredIndex < histogram.length) {
+				const highlightX = margin.left + panelState.hoveredIndex * barWidth + barWidth / 2;
+				ctx.strokeStyle = "#f08c00";
+				ctx.lineWidth = 1;
+				ctx.beginPath();
+				ctx.moveTo(highlightX, margin.top);
+				ctx.lineTo(highlightX, margin.top + innerHeight);
+				ctx.stroke();
+			}
+
+			ctx.fillStyle = "#2f445a";
+			ctx.font = "12px Segoe UI";
+			ctx.textAlign = "right";
+			ctx.fillText(`Vertex ${histogram.length}`, margin.left + innerWidth, canvas.height - 8);
+			ctx.textAlign = "left";
+
+			ctx.fillStyle = "#3b5875";
+			ctx.font = "12px Segoe UI";
+			ctx.fillText(GROUP_LABELS[key], margin.left + 2, 16);
+
+			panelState.drawMeta = {
+				margin,
+				innerWidth,
+				innerHeight,
+				barWidth,
+				histogram
+			};
+		}
+
+		function scheduleDraw() {
+			if (drawScheduled) return;
+			drawScheduled = true;
+			requestAnimationFrame(() => {
+				drawScheduled = false;
+				for (const panelState of panelStateByKey.values()) {
+					renderPanel(panelState);
+				}
+			});
+		}
+
+		function handlePanelHover(event, panelState) {
+			const meta = panelState.drawMeta;
+			if (!meta) {
+				hideTooltip();
+				return;
+			}
+
+			const rect = panelState.canvas.getBoundingClientRect();
+			const x = event.clientX - rect.left;
+			const y = event.clientY - rect.top;
+
+			const { margin, innerWidth, innerHeight, barWidth, histogram } = meta;
+			const insidePlot =
+				x >= margin.left &&
+				x <= margin.left + innerWidth &&
+				y >= margin.top &&
+				y <= margin.top + innerHeight;
+
+			if (!insidePlot || barWidth <= 0) {
+				if (panelState.hoveredIndex !== -1) {
+					panelState.hoveredIndex = -1;
+					scheduleDraw();
+				}
+				hideTooltip();
+				return;
+			}
+
+			const index = Math.floor((x - margin.left) / barWidth);
+			if (index < 0 || index >= histogram.length) {
+				if (panelState.hoveredIndex !== -1) {
+					panelState.hoveredIndex = -1;
+					scheduleDraw();
+				}
+				hideTooltip();
+				return;
+			}
+
+			const value = histogram[index] || 0;
+			hoverTooltipEl.textContent = `Vertex ${index + 1}\nOccurrences: ${value}\nGroup: ${GROUP_LABELS[panelState.key]}`;
+			hoverTooltipEl.style.display = "block";
+			positionTooltip(event);
+
+			if (panelState.hoveredIndex !== index) {
+				panelState.hoveredIndex = index;
+				scheduleDraw();
+			}
+		}
+
+		function attachPanelEvents(panelState) {
+			panelState.canvas.addEventListener("mousemove", (event) => handlePanelHover(event, panelState));
+			panelState.canvas.addEventListener("mouseleave", () => {
+				if (panelState.hoveredIndex !== -1) {
+					panelState.hoveredIndex = -1;
+					scheduleDraw();
+				}
+				hideTooltip();
+			});
+		}
+
+		function createPanel(key) {
+			const panelEl = document.createElement("div");
+			panelEl.className = "chart-panel";
+
+			const canvas = document.createElement("canvas");
+			canvas.className = "chart-canvas";
+
+			const legendEl = document.createElement("div");
+			legendEl.className = "panel-legend";
+
+			const barEl = document.createElement("div");
+			barEl.className = "panel-legend-bar";
+
+			const labelsEl = document.createElement("div");
+			labelsEl.className = "panel-legend-labels";
+
+			const minEl = document.createElement("span");
+			minEl.textContent = "0";
+
+			const maxEl = document.createElement("span");
+			maxEl.textContent = "0";
+
+			labelsEl.appendChild(minEl);
+			labelsEl.appendChild(maxEl);
+			legendEl.appendChild(barEl);
+			legendEl.appendChild(labelsEl);
+			panelEl.appendChild(canvas);
+			panelEl.appendChild(legendEl);
+
+			const panelState = {
+				key,
+				panelEl,
+				canvas,
+				ctx: canvas.getContext("2d"),
+				legendMin: minEl,
+				legendMax: maxEl,
+				hoveredIndex: -1,
+				drawMeta: null
+			};
+
+			attachPanelEvents(panelState);
+			return panelState;
+		}
+
+		function rebuildPanels() {
+			panelStateByKey.clear();
+			chartsStackEl.innerHTML = "";
+
+			const selectedKeys = getSelectedKeys();
+			if (!selectedKeys.length) {
+				const emptyEl = document.createElement("div");
+				emptyEl.id = "emptyState";
+				emptyEl.textContent = "Select at least one group to display histograms.";
+				chartsStackEl.style.gridTemplateRows = "1fr";
+				chartsStackEl.appendChild(emptyEl);
+				hideTooltip();
+				return;
+			}
+
+			chartsStackEl.style.gridTemplateRows = `repeat(${selectedKeys.length}, minmax(170px, 1fr))`;
+
+			for (const key of selectedKeys) {
+				const panelState = createPanel(key);
+				panelStateByKey.set(key, panelState);
+				chartsStackEl.appendChild(panelState.panelEl);
+			}
+		}
+
+		function refreshLayoutAndDraw() {
+			rebuildPanels();
+			scheduleDraw();
+		}
+
+		for (const key of Object.keys(checkboxes)) {
+			checkboxes[key].addEventListener("change", refreshLayoutAndDraw);
+		}
+
+		window.addEventListener("resize", scheduleDraw);
+
+		const socket = new WebSocket("ws://localhost:3214");
+
+		socket.onopen = function() {
+			statusEl.textContent = "Connected to server. Waiting for population data...";
+			socket.send(JSON.stringify({ act: "obs", data: ["individuals", "ui_events"] }));
+		};
+
+		socket.onmessage = function(event) {
+			const message = JSON.parse(event.data);
+
+			if (message.act === "resetCharts") {
+				resetAccumulatorState(vertexCount);
+				hideTooltip();
+				statusEl.textContent = "Process reset detected. Accumulators were cleared.";
+				updateCounts();
+				scheduleDraw();
+				return;
+			}
+
+			if (message.act !== "data" || message.type !== "individuals") return;
+			if (!message.data || !Array.isArray(message.data.population) || message.data.population.length === 0) return;
+
+			const population = message.data.population;
+			const maskLength = Array.isArray(population[0].nodeMask) ? population[0].nodeMask.length : 0;
+			if (!maskLength) return;
+
+			const incomingGeneration = Number(message.data.generation || (currentGeneration + 1));
+			ensureAccumulatorSize(maskLength);
+
+			if (incomingGeneration < currentGeneration) {
+				resetAccumulatorState(maskLength);
+				hideTooltip();
+			}
+
+			classifyPopulation(population);
+			processedGenerations++;
+			currentGeneration = incomingGeneration;
+
+			statusEl.textContent = `Generation ${currentGeneration} | Population ${population.length} | Accumulated in ${processedGenerations} generations`;
+
+			updateCounts();
+			scheduleDraw();
+		};
+
+		socket.onerror = function(err) {
+			console.error("WebSocket error", err);
+			statusEl.textContent = "WebSocket connection error.";
+		};
+
+		socket.onclose = function() {
+			statusEl.textContent = "WebSocket connection closed.";
+		};
+
+		resetAccumulatorState(0);
+		updateCounts();
+		refreshLayoutAndDraw();
+	</script>
 </body>
 </html>


### PR DESCRIPTION
Adicionado primeira versão da visualização de agregação. O histograma.

Add a new visualization page (public/html/histogram_aggregation_vis.html) that renders an interactive vertex-aggregation histogram. The page listens to a local WebSocket (ws://localhost:3214) for "individuals" messages, classifies population by fitness (top1/top2/top3/others), accumulates nodeMask occurrences across generations, and draws the histogram on a canvas with color scaling, hover tooltip, summary tags, legend and responsive resizing. Also update dashboard.html to add a menu item to open the new "Vertex Aggregation Histogram" view.